### PR TITLE
fix strerror not defined while building map-editor (Arch Linux)

### DIFF
--- a/src/MapEditor/src/MapEditorLightmap.cpp
+++ b/src/MapEditor/src/MapEditorLightmap.cpp
@@ -4,6 +4,8 @@
 
 #include <png.h>
 #include <cerrno>
+#include <string.h>
+#include <errno.h>
 
 void MapEditor::static_calculate_light_click(GuiButton *sender, void *data) {
     (reinterpret_cast<MapEditor *>(data))->calculate_light(false);


### PR DESCRIPTION
On Arch Linux the map-editor-build fails without these includes:

```
src/MapEditorLightmap.cpp:133:59: Error: »strerror« was not declared in this scope
             "Saving failed: " + std::string(strerror(errno)));
```
